### PR TITLE
fix [getPoolByToken]: fix the error message to send correct token symbols

### DIFF
--- a/src/chains/ergo/ergo.ts
+++ b/src/chains/ergo/ergo.ts
@@ -657,7 +657,7 @@ export class Ergo {
       (asset) => asset.symbol === quoteToken,
     );
     if (!realBaseToken || !realQuoteToken)
-      throw new Error(`${realBaseToken} or ${realQuoteToken} not found!`);
+      throw new Error(`${baseToken} or ${quoteToken} not found!`);
     return <Pool>(
       this.ammPools.find(
         (ammPool) =>


### PR DESCRIPTION
There was a mistake in Error message about token names.
Check it and if its OK merge it please.
Thanks in advance